### PR TITLE
Support for adding custom header fields to the output.

### DIFF
--- a/docs/sink-connector-config-options.rst
+++ b/docs/sink-connector-config-options.rst
@@ -34,6 +34,13 @@ Connection
   * Default: null
   * Importance: low
 
+``http.headers.additional``
+  Additional headers to forward in the http request in the format header:value separated by a comma
+
+  * Type: list
+  * Default: ""
+  * Importance: low
+
 ``oauth2.access.token.url``
   The URL to be used for fetching an access token. Client Credentials is the only supported grant type.
 

--- a/docs/sink-connector-config-options.rst
+++ b/docs/sink-connector-config-options.rst
@@ -35,10 +35,11 @@ Connection
   * Importance: low
 
 ``http.headers.additional``
-  Additional headers to forward in the http request in the format header:value separated by a comma
+  Additional headers to forward in the http request in the format header:value separated by a comma, headers are case-insensitive and no duplicate headers are allowed.
 
   * Type: list
   * Default: ""
+  * Valid Values: Key value pair string list with format header:value
   * Importance: low
 
 ``oauth2.access.token.url``
@@ -139,10 +140,15 @@ Delivery
   * Valid Values: [0,...]
   * Importance: medium
 
+Timeout
+^^^^^^^
+
 ``http.timeout``
-  The time in seconds to configure the http request timeout.
+  HTTP Response timeout (seconds). Default is 30 seconds.
 
   * Type: int
   * Default: 30
   * Valid Values: [1,...]
   * Importance: low
+
+

--- a/src/integration-test/java/io/aiven/kafka/connect/http/IntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/IntegrationTest.java
@@ -27,7 +27,6 @@ import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;

--- a/src/integration-test/java/io/aiven/kafka/connect/http/mockserver/HeaderRecorderHandler.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/mockserver/HeaderRecorderHandler.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.http.mockserver;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+
+
+
+public class HeaderRecorderHandler extends AbstractHandler {
+
+    private final List<Map<String, String>> recorderHeaders = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void handle(final String target,
+                       final Request baseRequest,
+                       final HttpServletRequest request,
+                       final HttpServletResponse response) throws IOException, ServletException {
+        final Map<String, String> requestHeaders = new HashMap<>();
+        request.getHeaderNames().asIterator().forEachRemaining(h -> requestHeaders.put(h, request.getHeader(h)));
+        recorderHeaders.add(requestHeaders);
+        response.setStatus(HttpServletResponse.SC_OK);
+        baseRequest.setHandled(true);
+    }
+
+    public List<Map<String, String>> recorderHeaders() {
+        return List.copyOf(recorderHeaders);
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/http/config/HttpSinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/http/config/HttpSinkConfig.java
@@ -20,9 +20,11 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
@@ -37,6 +39,8 @@ public class HttpSinkConfig extends AbstractConfig {
     private static final String HTTP_AUTHORIZATION_TYPE_CONFIG = "http.authorization.type";
     private static final String HTTP_HEADERS_AUTHORIZATION_CONFIG = "http.headers.authorization";
     private static final String HTTP_HEADERS_CONTENT_TYPE_CONFIG = "http.headers.content.type";
+    private static final String HTTP_HEADERS_ADDITIONAL = "http.headers.additional";
+    private static final String HTTP_HEADERS_ADDITIONAL_DELIMITER = ":";
 
     public static final String KAFKA_RETRY_BACKOFF_MS_CONFIG = "kafka.retry.backoff.ms";
 
@@ -148,6 +152,18 @@ public class HttpSinkConfig extends AbstractConfig {
             groupCounter++,
             ConfigDef.Width.MEDIUM,
             HTTP_HEADERS_CONTENT_TYPE_CONFIG
+        );
+
+        configDef.define(
+                HTTP_HEADERS_ADDITIONAL,
+                ConfigDef.Type.LIST,
+                Collections.EMPTY_LIST,
+                ConfigDef.Importance.LOW,
+                "Additional headers to forward in the http request in the format header:value separated by a comma",
+                CONNECTION_GROUP,
+                groupCounter++,
+                ConfigDef.Width.MEDIUM,
+                HTTP_HEADERS_ADDITIONAL
         );
 
         configDef.define(
@@ -432,6 +448,13 @@ public class HttpSinkConfig extends AbstractConfig {
 
     public final Long kafkaRetryBackoffMs() {
         return getLong(KAFKA_RETRY_BACKOFF_MS_CONFIG);
+    }
+
+    public Map<String, String> getAdditionalHeaders() {
+        return getList(HTTP_HEADERS_ADDITIONAL).stream()
+                .map(s -> s.split(HTTP_HEADERS_ADDITIONAL_DELIMITER))
+                .filter(h -> h.length > 1)
+                .collect(Collectors.toMap(h -> h[0], h -> h[1]));
     }
 
     public AuthorizationType authorizationType() {

--- a/src/main/java/io/aiven/kafka/connect/http/config/HttpSinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/http/config/HttpSinkConfig.java
@@ -158,8 +158,10 @@ public class HttpSinkConfig extends AbstractConfig {
                 HTTP_HEADERS_ADDITIONAL,
                 ConfigDef.Type.LIST,
                 Collections.EMPTY_LIST,
+                new KeyValuePairListValidator(HTTP_HEADERS_ADDITIONAL_DELIMITER),
                 ConfigDef.Importance.LOW,
-                "Additional headers to forward in the http request in the format header:value separated by a comma",
+                "Additional headers to forward in the http request in the format header:value separated by a comma, "
+                        + "headers are case-insensitive and no duplicate headers are allowed.",
                 CONNECTION_GROUP,
                 groupCounter++,
                 ConfigDef.Width.MEDIUM,
@@ -453,7 +455,6 @@ public class HttpSinkConfig extends AbstractConfig {
     public Map<String, String> getAdditionalHeaders() {
         return getList(HTTP_HEADERS_ADDITIONAL).stream()
                 .map(s -> s.split(HTTP_HEADERS_ADDITIONAL_DELIMITER))
-                .filter(h -> h.length > 1)
                 .collect(Collectors.toMap(h -> h[0], h -> h[1]));
     }
 

--- a/src/main/java/io/aiven/kafka/connect/http/config/KeyValuePairListValidator.java
+++ b/src/main/java/io/aiven/kafka/connect/http/config/KeyValuePairListValidator.java
@@ -53,6 +53,6 @@ public class KeyValuePairListValidator implements ConfigDef.Validator {
 
     @Override
     public String toString() {
-        return "Key value pair string list validator";
+        return "Key value pair string list with format header:value";
     }
 }

--- a/src/main/java/io/aiven/kafka/connect/http/config/KeyValuePairListValidator.java
+++ b/src/main/java/io/aiven/kafka/connect/http/config/KeyValuePairListValidator.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.http.config;
+
+import java.util.HashSet;
+import java.util.List;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+
+
+public class KeyValuePairListValidator implements ConfigDef.Validator {
+    private final String delimiter;
+
+    public KeyValuePairListValidator(final String delimiter) {
+        this.delimiter = delimiter;
+    }
+
+    @Override
+    public void ensureValid(final String name, final Object value) {
+        if (!(value instanceof List)) {
+            throw new ConfigException(name, value, "must be a list with the specified format");
+        }
+        @SuppressWarnings("unchecked")
+        final var values = (List<String>) value;
+        final var keySet = new HashSet<String>();
+        for (final String headerField : values) {
+            final var splitHeaderField = headerField.split(delimiter, -1);
+            final String lowerCaseKey = splitHeaderField[0].toLowerCase();
+            if (splitHeaderField.length != 2) {
+                throw new ConfigException("Header field should use format header:value");
+            }
+            if (keySet.contains(lowerCaseKey)) {
+                throw new ConfigException("Duplicate keys are not allowed (case-insensitive)");
+            }
+            keySet.add(lowerCaseKey);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "Key value pair string list validator";
+    }
+}

--- a/src/main/java/io/aiven/kafka/connect/http/sender/HttpRequestBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/HttpRequestBuilder.java
@@ -31,8 +31,12 @@ interface HttpRequestBuilder {
 
     HttpRequest.Builder build(final HttpSinkConfig config);
 
-    HttpRequestBuilder DEFAULT_HTTP_REQUEST_BUILDER = config ->
-            HttpRequest.newBuilder(config.httpUri()).timeout(REQUEST_HTTP_TIMEOUT);
+    HttpRequestBuilder DEFAULT_HTTP_REQUEST_BUILDER = config -> {
+        final var httpRequest = HttpRequest.newBuilder(config.httpUri()).timeout(REQUEST_HTTP_TIMEOUT);
+        config.getAdditionalHeaders().forEach(httpRequest::header);
+        return httpRequest;
+    };
+
 
     HttpRequestBuilder AUTH_HTTP_REQUEST_BUILDER = config -> {
         final var requestBuilder =

--- a/src/test/java/io/aiven/kafka/connect/http/config/HttpSinkConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/config/HttpSinkConfigTest.java
@@ -19,6 +19,7 @@ package io.aiven.kafka.connect.http.config;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -60,6 +61,7 @@ final class HttpSinkConfigTest {
         assertEquals(500, config.batchMaxSize());
         assertEquals(1, config.maxRetries());
         assertEquals(3000, config.retryBackoffMs());
+        assertEquals(Collections.emptyMap(), config.getAdditionalHeaders());
         assertNull(config.oauth2AccessTokenUri());
         assertNull(config.oauth2ClientId());
         assertNull(config.oauth2ClientSecret());
@@ -317,6 +319,38 @@ final class HttpSinkConfigTest {
 
         final HttpSinkConfig config = new HttpSinkConfig(properties);
         assertEquals("application/json", config.headerContentType());
+    }
+
+    @Test
+    void headerAdditionalFields() {
+        final Map<String, String> properties = Map.of(
+                "http.url", "http://localhost:8090",
+                "http.authorization.type", "none",
+                "http.headers.additional", "test:value,test2:value2,test3,test4:value4"
+        );
+
+        final HttpSinkConfig config = new HttpSinkConfig(properties);
+        final var additionalHeaders = config.getAdditionalHeaders();
+
+        assertEquals(3, additionalHeaders.size());
+        assertEquals("value", additionalHeaders.get("test"));
+        assertEquals("value2", additionalHeaders.get("test2"));
+        assertEquals("value4", additionalHeaders.get("test4"));
+    }
+
+    @Test
+    void headerAdditionalField() {
+        final Map<String, String> properties = Map.of(
+                "http.url", "http://localhost:8090",
+                "http.authorization.type", "none",
+                "http.headers.additional", "test:value"
+        );
+
+        final HttpSinkConfig config = new HttpSinkConfig(properties);
+        final var additionalHeaders = config.getAdditionalHeaders();
+
+        assertEquals(1, additionalHeaders.size());
+        assertEquals("value", additionalHeaders.get("test"));
     }
 
     @Test

--- a/src/test/java/io/aiven/kafka/connect/http/config/HttpSinkConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/config/HttpSinkConfigTest.java
@@ -326,7 +326,7 @@ final class HttpSinkConfigTest {
         final Map<String, String> properties = Map.of(
                 "http.url", "http://localhost:8090",
                 "http.authorization.type", "none",
-                "http.headers.additional", "test:value,test2:value2,test3,test4:value4"
+                "http.headers.additional", "test:value,test2:value2,test4:value4"
         );
 
         final HttpSinkConfig config = new HttpSinkConfig(properties);


### PR DESCRIPTION
This allows the injection of custom headers on the output.
For this a new config item was added `http.headers.additional` with the format: `header1:value1,header2:value2`; 

The configured headers will be added to the output. This was done by adding the configured headers at the default builder `DEFAULT_HTTP_REQUEST_BUILDER`.

Unit/integration tests were also implemented.

closes #36 