### PR TITLE
Add http timeout configuration

### DIFF
--- a/docs/sink-connector-config-options.rst
+++ b/docs/sink-connector-config-options.rst
@@ -132,4 +132,10 @@ Delivery
   * Valid Values: [0,...]
   * Importance: medium
 
+``http.timeout``
+  The time in seconds to configure the http request timeout.
 
+  * Type: int
+  * Default: 30
+  * Valid Values: [1,...]
+  * Importance: low

--- a/src/main/java/io/aiven/kafka/connect/http/config/HttpSinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/http/config/HttpSinkConfig.java
@@ -55,6 +55,9 @@ public class HttpSinkConfig extends AbstractConfig {
     private static final String MAX_RETRIES_CONFIG = "max.retries";
     private static final String RETRY_BACKOFF_MS_CONFIG = "retry.backoff.ms";
 
+    private static final String TIMEOUT_GROUP = "Timeout";
+    private static final String HTTP_TIMEOUT_CONFIG = "http.timeout";
+
     public static final String NAME_CONFIG = "name";
 
     public static ConfigDef configDef() {
@@ -62,6 +65,7 @@ public class HttpSinkConfig extends AbstractConfig {
         addConnectionConfigGroup(configDef);
         addBatchingConfigGroup(configDef);
         addRetriesConfigGroup(configDef);
+        addTimeoutConfigGroup(configDef);
         return configDef;
     }
 
@@ -373,6 +377,22 @@ public class HttpSinkConfig extends AbstractConfig {
         );
     }
 
+    private static void addTimeoutConfigGroup(final ConfigDef configDef) {
+        int groupCounter = 0;
+        configDef.define(
+            HTTP_TIMEOUT_CONFIG,
+            ConfigDef.Type.INT,
+            30,
+            ConfigDef.Range.atLeast(1),
+            ConfigDef.Importance.LOW,
+            "HTTP Response timeout (seconds). Default is 30 seconds.",
+            TIMEOUT_GROUP,
+            groupCounter++,
+            ConfigDef.Width.SHORT,
+            HTTP_TIMEOUT_CONFIG
+        );
+    }
+
     public HttpSinkConfig(final Map<String, String> properties) {
         super(configDef(), properties);
         validate();
@@ -461,6 +481,10 @@ public class HttpSinkConfig extends AbstractConfig {
 
     public int retryBackoffMs() {
         return getInt(RETRY_BACKOFF_MS_CONFIG);
+    }
+
+    public int httpTimeout() {
+        return getInt(HTTP_TIMEOUT_CONFIG);
     }
 
     public final String connectorName() {

--- a/src/main/java/io/aiven/kafka/connect/http/sender/AccessTokenHttpRequestBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/AccessTokenHttpRequestBuilder.java
@@ -19,6 +19,7 @@ package io.aiven.kafka.connect.http.sender;
 import java.net.URLEncoder;
 import java.net.http.HttpRequest;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.Objects;
 import java.util.StringJoiner;
@@ -38,7 +39,7 @@ class AccessTokenHttpRequestBuilder implements HttpRequestBuilder {
         Objects.requireNonNull(config.oauth2AccessTokenUri(), "oauth2AccessTokenUri");
         final var accessTokenRequestBuilder = HttpRequest
                         .newBuilder(config.oauth2AccessTokenUri())
-                        .timeout(REQUEST_HTTP_TIMEOUT)
+                        .timeout(Duration.ofSeconds(config.httpTimeout()))
                         .header(HEADER_CONTENT_TYPE, "application/x-www-form-urlencoded");
 
         final var accessTokenRequestBodyBuilder = new StringJoiner("&");

--- a/src/main/java/io/aiven/kafka/connect/http/sender/HttpRequestBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/HttpRequestBuilder.java
@@ -27,12 +27,12 @@ interface HttpRequestBuilder {
 
     String HEADER_CONTENT_TYPE = "Content-Type";
 
-    Duration REQUEST_HTTP_TIMEOUT = Duration.ofSeconds(30);
+    //Duration REQUEST_HTTP_TIMEOUT = Duration.ofSeconds(30);
 
     HttpRequest.Builder build(final HttpSinkConfig config);
 
     HttpRequestBuilder DEFAULT_HTTP_REQUEST_BUILDER = config ->
-            HttpRequest.newBuilder(config.httpUri()).timeout(REQUEST_HTTP_TIMEOUT);
+            HttpRequest.newBuilder(config.httpUri()).timeout(Duration.ofSeconds(config.httpTimeout()));
 
     HttpRequestBuilder AUTH_HTTP_REQUEST_BUILDER = config -> {
         final var requestBuilder =

--- a/src/main/java/io/aiven/kafka/connect/http/sender/HttpRequestBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/HttpRequestBuilder.java
@@ -27,8 +27,6 @@ interface HttpRequestBuilder {
 
     String HEADER_CONTENT_TYPE = "Content-Type";
 
-    //Duration REQUEST_HTTP_TIMEOUT = Duration.ofSeconds(30);
-
     HttpRequest.Builder build(final HttpSinkConfig config);
 
     HttpRequestBuilder DEFAULT_HTTP_REQUEST_BUILDER = config ->

--- a/src/test/java/io/aiven/kafka/connect/http/config/HttpSinkConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/config/HttpSinkConfigTest.java
@@ -447,4 +447,26 @@ final class HttpSinkConfigTest {
         assertEquals(6000, config.kafkaRetryBackoffMs());
     }
 
+    @Test
+    void defaultHttpTimeout() {
+        final Map<String, String> properties = Map.of(
+                "http.url", "http://localhost:8090",
+                "http.authorization.type", "none"
+        );
+
+        final var config = new HttpSinkConfig(properties);
+        assertEquals(30, config.httpTimeout());
+    }
+
+    @Test
+    void customHttpTimeout() {
+        final Map<String, String> properties = Map.of(
+                "http.url", "http://localhost:8090",
+                "http.authorization.type", "none",
+                "http.timeout", "5"
+        );
+
+        final var config = new HttpSinkConfig(properties);
+        assertEquals(5, config.httpTimeout());
+    }
 }


### PR DESCRIPTION
Adding property `http.timeout` to be able to configure the http request
timeout duration. If not set the current default of 30 seconds is
used.

We use this connector for work and have a need to fail faster than the default 30 second timeout when the web endpoint is non responsive for some reason.

There are several unit tests added, but I couldn't find instructions for setting up any integrated tests and I am new to Mockito so don't know how to mock HttpClient to simulate an http delayed response to force the timeout. But I did test it manually.