### PR TITLE
Change header to Aiven and contributors, also allow copyright year ranges

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2021 Aiven Oy and http-connector-for-apache-kafka project contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy
+ * Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-// Copyright 2019 Aiven Oy
+// Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/config/checkstyle/java.header
+++ b/config/checkstyle/java.header
@@ -1,5 +1,5 @@
 /\*
- \* Copyright 20(19|2[0-9]) Aiven Oy
+ \* Copyright (20(19|2[0-9]) - )?20(19|2[0-9]) Aiven Oy and http-connector-for-apache-kafka project contributors
  \*
  \* Licensed under the Apache License, Version 2.0 \(the "License"\);
  \* you may not use this file except in compliance with the License.

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-// Copyright 2019 Aiven Oy
+// Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/integration-test/java/io/aiven/kafka/connect/http/AvroIntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/AvroIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Aiven Oy
+ * Copyright 2021 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/integration-test/java/io/aiven/kafka/connect/http/ConnectRunner.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/ConnectRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy
+ * Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/integration-test/java/io/aiven/kafka/connect/http/IntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/IntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy
+ * Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/integration-test/java/io/aiven/kafka/connect/http/SchemaRegistryContainer.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/SchemaRegistryContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Aiven Oy
+ * Copyright 2021 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/integration-test/java/io/aiven/kafka/connect/http/TestUtils.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy
+ * Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/integration-test/java/io/aiven/kafka/connect/http/mockserver/BodyRecorderHandler.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/mockserver/BodyRecorderHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy
+ * Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/integration-test/java/io/aiven/kafka/connect/http/mockserver/HeaderRecorderHandler.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/mockserver/HeaderRecorderHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy
+ * Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/integration-test/java/io/aiven/kafka/connect/http/mockserver/MockServer.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/mockserver/MockServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy
+ * Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/integration-test/java/io/aiven/kafka/connect/http/mockserver/RequestFailingHandler.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/mockserver/RequestFailingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy
+ * Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/aiven/kafka/connect/http/HttpSinkConnector.java
+++ b/src/main/java/io/aiven/kafka/connect/http/HttpSinkConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy
+ * Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/aiven/kafka/connect/http/HttpSinkTask.java
+++ b/src/main/java/io/aiven/kafka/connect/http/HttpSinkTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Aiven Oy
+ * Copyright 2021 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/aiven/kafka/connect/http/Version.java
+++ b/src/main/java/io/aiven/kafka/connect/http/Version.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy
+ * Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/aiven/kafka/connect/http/config/AuthorizationType.java
+++ b/src/main/java/io/aiven/kafka/connect/http/config/AuthorizationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy
+ * Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/aiven/kafka/connect/http/config/FixedSetRecommender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/config/FixedSetRecommender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy
+ * Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/aiven/kafka/connect/http/config/HttpSinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/http/config/HttpSinkConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy
+ * Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/aiven/kafka/connect/http/config/KeyValuePairListValidator.java
+++ b/src/main/java/io/aiven/kafka/connect/http/config/KeyValuePairListValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy
+ * Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/aiven/kafka/connect/http/config/NonBlankStringValidator.java
+++ b/src/main/java/io/aiven/kafka/connect/http/config/NonBlankStringValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Aiven Oy
+ * Copyright 2021 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/aiven/kafka/connect/http/config/OAuth2AuthorizationMode.java
+++ b/src/main/java/io/aiven/kafka/connect/http/config/OAuth2AuthorizationMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Aiven Oy
+ * Copyright 2021 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/aiven/kafka/connect/http/config/UrlValidator.java
+++ b/src/main/java/io/aiven/kafka/connect/http/config/UrlValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy
+ * Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/aiven/kafka/connect/http/converter/JsonRecordValueConverter.java
+++ b/src/main/java/io/aiven/kafka/connect/http/converter/JsonRecordValueConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Aiven Oy
+ * Copyright 2021 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/aiven/kafka/connect/http/converter/RecordValueConverter.java
+++ b/src/main/java/io/aiven/kafka/connect/http/converter/RecordValueConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Aiven Oy
+ * Copyright 2021 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/aiven/kafka/connect/http/recordsender/BatchRecordSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/recordsender/BatchRecordSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy
+ * Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/aiven/kafka/connect/http/recordsender/RecordSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/recordsender/RecordSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy
+ * Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/aiven/kafka/connect/http/recordsender/SingleRecordSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/recordsender/SingleRecordSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy
+ * Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/aiven/kafka/connect/http/sender/AccessTokenHttpRequestBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/AccessTokenHttpRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Aiven Oy
+ * Copyright 2021 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/aiven/kafka/connect/http/sender/HttpRequestBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/HttpRequestBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Aiven Oy
+ * Copyright 2021 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/aiven/kafka/connect/http/sender/HttpResponseHandler.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/HttpResponseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Aiven Oy
+ * Copyright 2021 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/aiven/kafka/connect/http/sender/HttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/HttpSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy
+ * Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/io/aiven/kafka/connect/http/sender/OAuth2HttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/OAuth2HttpSender.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Aiven Oy
+ * Copyright 2021 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/aiven/kafka/connect/http/config/HttpSinkConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/config/HttpSinkConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy
+ * Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/aiven/kafka/connect/http/config/HttpSinkConfigValidationTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/config/HttpSinkConfigValidationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy
+ * Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/aiven/kafka/connect/http/converter/RecordValueConverterTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/converter/RecordValueConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Aiven Oy
+ * Copyright 2021 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/aiven/kafka/connect/http/sender/AccessTokenHttpRequestBuilderTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/sender/AccessTokenHttpRequestBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Aiven Oy
+ * Copyright 2021 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/io/aiven/kafka/connect/http/sender/OAuth2HttpSenderTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/sender/OAuth2HttpSenderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Aiven Oy
+ * Copyright 2021 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Copyright is granted to Aiven and project's contributors.

Also in favor of flexibility in copyright headers, this now accepts a range of years. This should be better than simply stating a year to:
- show when was the file last updated
- show when was the file firstly created (protection against ownership)