### PR TITLE
Add batch.{prefix,suffix,separator} configuration properties

### DIFF
--- a/docs/sink-connector-config-options.rst
+++ b/docs/sink-connector-config-options.rst
@@ -118,7 +118,7 @@ Batching
   Prefix added to record batches. Written once before the first record of a batch. Defaults to "" and may contain escape sequences like ``\n``.
 
   * Type: string
-  * Default: null
+  * Default: ""
   * Importance: high
 
 ``batch.suffix``

--- a/docs/sink-connector-config-options.rst
+++ b/docs/sink-connector-config-options.rst
@@ -114,6 +114,27 @@ Batching
   * Valid Values: [1,...,1000000]
   * Importance: medium
 
+``batch.prefix``
+  Prefix added to record batches. Written once before the first record of a batch. Defaults to "" and may contain escape sequences like ``\n``.
+
+  * Type: string
+  * Default: null
+  * Importance: high
+
+``batch.suffix``
+  Suffix added to record batches. Written once after the last record of a batch. Defaults to "\n" (for backwards compatibility) and may contain escape sequences.
+
+  * Type: string
+  * Default: null
+  * Importance: high
+
+``batch.separator``
+  Separator for records in a batch. Defaults to "\n" and may contain escape sequences.
+
+  * Type: string
+  * Default: null
+  * Importance: high
+
 Delivery
 ^^^^^^^^
 

--- a/src/main/java/io/aiven/kafka/connect/http/config/HttpSinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/http/config/HttpSinkConfig.java
@@ -57,8 +57,11 @@ public class HttpSinkConfig extends AbstractConfig {
     private static final String BATCHING_ENABLED_CONFIG = "batching.enabled";
     private static final String BATCH_MAX_SIZE_CONFIG = "batch.max.size";
     private static final String BATCH_PREFIX_CONFIG = "batch.prefix";
+    private static final String BATCH_PREFIX_DEFAULT = "";
     private static final String BATCH_SUFFIX_CONFIG = "batch.suffix";
+    private static final String BATCH_SUFFIX_DEFAULT = "\n";
     private static final String BATCH_SEPARATOR_CONFIG = "batch.separator";
+    private static final String BATCH_SEPARATOR_DEFAULT = "\n";
 
     private static final String DELIVERY_GROUP = "Delivery";
     private static final String MAX_RETRIES_CONFIG = "max.retries";
@@ -336,14 +339,10 @@ public class HttpSinkConfig extends AbstractConfig {
             BATCHING_GROUP
         );
 
-        // ConfigKey automatically calls trim() on strings, but characters discarded by that method
-        // are commonly used as delimiters, including our default of "\n" for suffix and separator.
-        // We work around that by supplying null here the injecting the real default in the accessors.
-
         configDef.define(
             BATCH_PREFIX_CONFIG,
             ConfigDef.Type.STRING,
-            null,
+            BATCH_PREFIX_DEFAULT,
             ConfigDef.Importance.HIGH,
             "Prefix added to record batches. Written once before the first record of a batch. "
                     + "Defaults to \"\" and may contain escape sequences like ``\\n``.",
@@ -352,6 +351,10 @@ public class HttpSinkConfig extends AbstractConfig {
             ConfigDef.Width.MEDIUM,
             BATCHING_GROUP
         );
+
+        // ConfigKey automatically calls trim() on strings, but characters discarded by that method
+        // are commonly used as delimiters, including our default of "\n" for suffix and separator.
+        // We work around that by supplying null here the injecting the real default in the accessors.
 
         configDef.define(
             BATCH_SUFFIX_CONFIG,
@@ -556,15 +559,15 @@ public class HttpSinkConfig extends AbstractConfig {
     }
 
     public final String batchPrefix() {
-        return getOriginalString(BATCH_PREFIX_CONFIG, "");
+        return getOriginalString(BATCH_PREFIX_CONFIG, BATCH_PREFIX_DEFAULT);
     }
 
     public final String batchSuffix() {
-        return getOriginalString(BATCH_SUFFIX_CONFIG, "\n");
+        return getOriginalString(BATCH_SUFFIX_CONFIG, BATCH_SUFFIX_DEFAULT);
     }
 
     public final String batchSeparator() {
-        return getOriginalString(BATCH_SEPARATOR_CONFIG, "\n");
+        return getOriginalString(BATCH_SEPARATOR_CONFIG, BATCH_SEPARATOR_DEFAULT);
     }
 
     public int maxRetries() {

--- a/src/main/java/io/aiven/kafka/connect/http/config/HttpSinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/http/config/HttpSinkConfig.java
@@ -555,6 +555,7 @@ public class HttpSinkConfig extends AbstractConfig {
     // White space is significant for our batch delimiters but ConfigKey trims it out
     // so we need to check the originals rather than using the normal machinery.
     private String getOriginalString(final String key, final String defaultValue) {
+        get(key); // Assess key via the normal flow so it isn't reported as "unused".
         return originalsStrings().getOrDefault(key, defaultValue);
     }
 

--- a/src/main/java/io/aiven/kafka/connect/http/recordsender/RecordSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/recordsender/RecordSender.java
@@ -38,7 +38,12 @@ public abstract class RecordSender {
 
     public static RecordSender createRecordSender(final HttpSender httpSender, final HttpSinkConfig config) {
         if (config.batchingEnabled()) {
-            return new BatchRecordSender(httpSender, config.batchMaxSize());
+            return new BatchRecordSender(
+                    httpSender,
+                    config.batchMaxSize(),
+                    config.batchPrefix(),
+                    config.batchSuffix(),
+                    config.batchSeparator());
         } else {
             return new SingleRecordSender(httpSender);
         }


### PR DESCRIPTION
These properties are similar to those in the Confluent connector
and are useful for supporting some additionally flexibility around
how exactly batch requests are formatted, including a JSON array
format when individual records are serialized as JSON.

The default values of "\n" for suffix and separator are chosen for
backwards compatibility with the current behavior when the new
properties are not specified, as confirmed by the unmodified
testBatching() integration test.

We've been running this in production without issue, specifically
with `[`, `]`, and `,` for a JSON array style batching.