### PR TITLE
Add ErrantRecordReporter support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,14 +66,14 @@ wrapper {
 ext {
     moduleName = "io.aiven.kafka.connect.http"
 
-    avroVersion = "1.8.1" // Version 1.8.1 brings Jackson 1.9.x/org.codehaus.jackson package for Avro and Confluent Platform 4.1.4.
+    avroVersion = "1.9.2" // Version 1.9.2 brings Jackson 2.10.2 package for Avro
     confluentPlatformVersion = "6.0.2" // For compatibility tests use version 6.0.2 to match Kafka 2.6.
                                        // NOTE: Confluent Platform v6.0.3 has a dependency mismatch issue.
     hamcrestVersion = "2.2"
     jacksonVersion = "2.13.2" // This Jackson is used in the tests.
     jupiterVersion = "5.8.2"
     kafkaVersion = '2.6.3'
-    jettyVersion = "9.4.45.v20220203"
+    jettyVersion = "9.4.39.v20210325"
     junit4Version = "4.13.2"
     jsr305Version = "3.0.2"
     log4jVersion = "2.17.2"

--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ ext {
     moduleName = "io.aiven.kafka.connect.http"
 
     avroVersion = "1.8.1" // Version 1.8.1 brings Jackson 1.9.x/org.codehaus.jackson package for Avro and Confluent Platform 4.1.4.
-    confluentPlatformVersion = "6.0.2" // For compatibility tests use version 6.0.2 to match Kafka 2.6. 
+    confluentPlatformVersion = "6.0.2" // For compatibility tests use version 6.0.2 to match Kafka 2.6.
                                        // NOTE: Confluent Platform v6.0.3 has a dependency mismatch issue.
     hamcrestVersion = "2.2"
     jacksonVersion = "2.13.2" // This Jackson is used in the tests.

--- a/build.gradle
+++ b/build.gradle
@@ -66,12 +66,13 @@ wrapper {
 ext {
     moduleName = "io.aiven.kafka.connect.http"
 
-    avroVersion = "1.10.0" // Version 1.8.1 brings Jackson 1.9.x/org.codehaus.jackson package for Avro and Confluent Platform 4.1.4.
-    confluentPlatformVersion = "6.2.2" // For compatibility tests use version 6.2.2 to match Kafka 2.8.1.
+    avroVersion = "1.8.1" // Version 1.8.1 brings Jackson 1.9.x/org.codehaus.jackson package for Avro and Confluent Platform 4.1.4.
+    confluentPlatformVersion = "6.0.2" // For compatibility tests use version 6.0.2 to match Kafka 2.6. 
+                                       // NOTE: Confluent Platform v6.0.3 has a dependency mismatch issue.
     hamcrestVersion = "2.2"
     jacksonVersion = "2.13.2" // This Jackson is used in the tests.
     jupiterVersion = "5.8.2"
-    kafkaVersion = '2.8.1'
+    kafkaVersion = '2.6.3'
     jettyVersion = "9.4.45.v20220203"
     junit4Version = "4.13.2"
     jsr305Version = "3.0.2"

--- a/build.gradle
+++ b/build.gradle
@@ -66,13 +66,13 @@ wrapper {
 ext {
     moduleName = "io.aiven.kafka.connect.http"
 
-    avroVersion = "1.8.1" // Version 1.8.1 brings Jackson 1.9.x/org.codehaus.jackson package for Avro and Confluent Platform 4.1.4.
-    confluentPlatformVersion = "4.1.4" // For compatibility tests use version 4.1.4.
+    avroVersion = "1.10.0" // Version 1.8.1 brings Jackson 1.9.x/org.codehaus.jackson package for Avro and Confluent Platform 4.1.4.
+    confluentPlatformVersion = "6.2.2" // For compatibility tests use version 6.2.2 to match Kafka 2.8.1.
     hamcrestVersion = "2.2"
     jacksonVersion = "2.13.2" // This Jackson is used in the tests.
     jupiterVersion = "5.8.2"
-    kafkaVersion = '2.6.3'
-    jettyVersion = "9.4.11.v20180605"
+    kafkaVersion = '2.8.1'
+    jettyVersion = "9.4.45.v20220203"
     junit4Version = "4.13.2"
     jsr305Version = "3.0.2"
     log4jVersion = "2.17.2"
@@ -131,7 +131,6 @@ dependencies {
     testRuntimeOnly "org.apache.kafka:connect-json:$kafkaVersion"
     testRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter:$jupiterVersion"
-    testRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 
     testImplementation "org.apache.kafka:connect-api:$kafkaVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-api:$jupiterVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ ext {
     hamcrestVersion = "2.2"
     jacksonVersion = "2.13.2" // This Jackson is used in the tests.
     jupiterVersion = "5.8.2"
-    kafkaVersion = "2.0.1" // Oldest version supported, new versions are backwards compatible.
+    kafkaVersion = '2.6.3'
     jettyVersion = "9.4.11.v20180605"
     junit4Version = "4.13.2"
     jsr305Version = "3.0.2"

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -19,7 +19,7 @@
         "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 <suppressions>
   <!-- Switch off these complexity metrics for integration tests, as in them we must instantiate many classes explicitly. -->
-  <suppress checks="ClassFanOutComplexity" files="(IntegrationTest|ConnectRunner).java" />
+  <suppress checks="ClassFanOutComplexity" files="(IntegrationTest|ConnectRunner|ErrantRecordTest).java" />
   <suppress checks="ClassDataAbstractionCoupling" files="(IntegrationTest|ConnectRunner).java" />
   <suppress checks="MethodLength" files="(HttpSinkConfig).java" />
   <suppress checks="CyclomaticComplexity" files="(HttpSinkConfig).java" />

--- a/src/integration-test/java/io/aiven/kafka/connect/http/AvroIntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/AvroIntegrationTest.java
@@ -79,13 +79,13 @@ public class AvroIntegrationTest {
 
     private static File pluginsDir;
 
-    private static final String DEFAULT_TAG = "5.4.3";
+    private static final String DEFAULT_TAG = "6.2.2";
 
     private static final DockerImageName DEFAULT_IMAGE_NAME =
             DockerImageName.parse("confluentinc/cp-kafka").withTag(DEFAULT_TAG);
 
     @Container
-    private final KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.2"))
+    private final KafkaContainer kafka = new KafkaContainer(DEFAULT_IMAGE_NAME)
             .withNetwork(Network.newNetwork())
             .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false");
 

--- a/src/integration-test/java/io/aiven/kafka/connect/http/AvroIntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/AvroIntegrationTest.java
@@ -56,13 +56,8 @@ import org.testcontainers.utility.DockerImageName;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 @Testcontainers
 public class AvroIntegrationTest {
-
-    private static final Logger log = LoggerFactory.getLogger(AvroIntegrationTest.class);
 
     private static final String HTTP_PATH = "/send-data-here";
     private static final String AUTHORIZATION = "Bearer some-token";

--- a/src/integration-test/java/io/aiven/kafka/connect/http/AvroIntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/AvroIntegrationTest.java
@@ -79,7 +79,7 @@ public class AvroIntegrationTest {
 
     private static File pluginsDir;
 
-    private static final String DEFAULT_TAG = "6.2.2";
+    private static final String DEFAULT_TAG = "6.0.2";
 
     private static final DockerImageName DEFAULT_IMAGE_NAME =
             DockerImageName.parse("confluentinc/cp-kafka").withTag(DEFAULT_TAG);

--- a/src/integration-test/java/io/aiven/kafka/connect/http/AvroIntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/AvroIntegrationTest.java
@@ -56,8 +56,14 @@ import org.testcontainers.utility.DockerImageName;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 @Testcontainers
 public class AvroIntegrationTest {
+
+    private static final Logger log = LoggerFactory.getLogger(AvroIntegrationTest.class);
+
     private static final String HTTP_PATH = "/send-data-here";
     private static final String AUTHORIZATION = "Bearer some-token";
     private static final String CONTENT_TYPE = "application/json";
@@ -84,7 +90,7 @@ public class AvroIntegrationTest {
             DockerImageName.parse("confluentinc/cp-kafka").withTag(DEFAULT_TAG);
 
     @Container
-    private final KafkaContainer kafka = new KafkaContainer(DEFAULT_IMAGE_NAME)
+    private final KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.2"))
             .withNetwork(Network.newNetwork())
             .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false");
 
@@ -122,6 +128,7 @@ public class AvroIntegrationTest {
 
         final Properties adminClientConfig = new Properties();
         adminClientConfig.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers());
+
         adminClient = AdminClient.create(adminClientConfig);
 
         final Map<String, Object> producerProps = Map.of(

--- a/src/integration-test/java/io/aiven/kafka/connect/http/ConnectRunner.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/ConnectRunner.java
@@ -65,9 +65,7 @@ final class ConnectRunner {
         // These don't matter much (each connector sets its own converters), but need to be filled with valid classes.
         workerProps.put("key.converter", "org.apache.kafka.connect.converters.ByteArrayConverter");
         workerProps.put("value.converter", "org.apache.kafka.connect.converters.ByteArrayConverter");
-        workerProps.put("internal.key.converter", "org.apache.kafka.connect.json.JsonConverter");
         workerProps.put("internal.key.converter.schemas.enable", "false");
-        workerProps.put("internal.value.converter", "org.apache.kafka.connect.json.JsonConverter");
         workerProps.put("internal.value.converter.schemas.enable", "false");
 
         // Don't need it since we'll memory MemoryOffsetBackingStore.
@@ -90,6 +88,7 @@ final class ConnectRunner {
         herder = new StandaloneHerder(worker, "cluster-id", allConnectorClientConfigOverridePolicy);
 
         final RestServer rest = new RestServer(config);
+        rest.initializeServer();
 
         connect = new Connect(herder, rest);
 

--- a/src/integration-test/java/io/aiven/kafka/connect/http/ConnectRunner.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/ConnectRunner.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.connect.connector.policy.AllConnectorClientConfigOverridePolicy;
 import org.apache.kafka.connect.runtime.Connect;
 import org.apache.kafka.connect.runtime.ConnectorConfig;
 import org.apache.kafka.connect.runtime.Herder;
@@ -80,9 +81,13 @@ final class ConnectRunner {
         final Plugins plugins = new Plugins(workerProps);
         final StandaloneConfig config = new StandaloneConfig(workerProps);
 
+        final AllConnectorClientConfigOverridePolicy allConnectorClientConfigOverridePolicy = 
+                    new AllConnectorClientConfigOverridePolicy();
+
         final Worker worker = new Worker(
-            workerId, time, plugins, config, new MemoryOffsetBackingStore());
-        herder = new StandaloneHerder(worker, "cluster-id");
+            workerId, time, plugins, config, new MemoryOffsetBackingStore(),
+            allConnectorClientConfigOverridePolicy);
+        herder = new StandaloneHerder(worker, "cluster-id", allConnectorClientConfigOverridePolicy);
 
         final RestServer rest = new RestServer(config);
 

--- a/src/integration-test/java/io/aiven/kafka/connect/http/ErrantRecordTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/ErrantRecordTest.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.http;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.time.Duration;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+
+import io.aiven.kafka.connect.http.mockserver.BodyRecorderHandler;
+import io.aiven.kafka.connect.http.mockserver.FailingPeriodicHandler;
+import io.aiven.kafka.connect.http.mockserver.MockServer;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@Testcontainers
+final class ErrantRecordTest {
+    private static final Logger log = LoggerFactory.getLogger(ErrantRecordTest.class);
+
+    private static final String HTTP_PATH = "/send-data-here";
+    private static final String AUTHORIZATION = "Bearer some-token";
+    private static final String CONTENT_TYPE = "application/json";
+    private static final String CONTENT_TYPE_HEADER = "Content-Type";
+
+    private static final String CONNECTOR_NAME = "test-source-connector";
+
+    private static final String TEST_TOPIC = "test-topic";
+    private static final int TEST_TOPIC_PARTITIONS = 1;
+
+    private static final String TEST_DLQ_TOPIC = "test-dlq-topic";
+    private static final int TEST_DLQ_TOPIC_PARTITIONS = 1;
+    private static final String TEST_DLQ_TOPIC_REPLICATION_FACTOR = "1";
+
+    private static final int FAIL_PERIOD = 3;
+
+    static final String JSON_PATTERN = "{\"record\":\"%s\",\"recordValue\":\"%s\"}";
+
+    private static File pluginsDir;
+
+    private static final String DEFAULT_TAG = "5.4.3";
+
+    private static final DockerImageName DEFAULT_IMAGE_NAME =
+            DockerImageName.parse("confluentinc/cp-kafka").withTag(DEFAULT_TAG);
+
+    @Container
+    private final KafkaContainer kafka = new KafkaContainer(DEFAULT_IMAGE_NAME)
+        .withNetwork(Network.newNetwork())
+        .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false");
+
+    private AdminClient adminClient;
+    private KafkaProducer<String, Record> producer;
+    private KafkaConsumer<String, Record> consumer;
+
+    private ConnectRunner connectRunner;
+
+    private MockServer mockServer;
+
+    @BeforeAll
+    static void setUpAll() throws IOException, InterruptedException {
+        final File testDir = Files.createTempDirectory("http-connector-for-apache-kafka-").toFile();
+        testDir.deleteOnExit();
+
+        pluginsDir = new File(testDir, "plugins/");
+        assert pluginsDir.mkdirs();
+
+        // Unpack the library distribution.
+        final File transformDir = new File(pluginsDir, "http-connector-for-apache-kafka/");
+        assert transformDir.mkdirs();
+        final File distFile = new File(System.getProperty("integration-test.distribution.file.path"));
+        assert distFile.exists();
+        final String cmd = String.format("tar -xf %s --strip-components=1 -C %s",
+            distFile.toString(), transformDir.toString());
+        final Process p = Runtime.getRuntime().exec(cmd);
+        assert p.waitFor() == 0;
+    }
+
+    @BeforeEach
+    void setUp() throws ExecutionException, InterruptedException {
+        mockServer = new MockServer(HTTP_PATH, AUTHORIZATION, CONTENT_TYPE);
+
+        final Properties adminClientConfig = new Properties();
+        adminClientConfig.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers());
+        adminClient = AdminClient.create(adminClientConfig);
+
+        final Map<String, Object> producerProps = Map.of(
+            ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers(),
+            ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "io.confluent.kafka.serializers.KafkaJsonSerializer",
+            ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "io.confluent.kafka.serializers.KafkaJsonSerializer",
+            ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, "1"
+        );
+        producer = new KafkaProducer<>(producerProps);
+
+        // set up the test topic
+        final List<NewTopic> testTopics = new ArrayList<NewTopic>();
+        testTopics.add(new NewTopic(TEST_TOPIC, TEST_TOPIC_PARTITIONS, (short) 1));
+        // and the DLQ topic
+        testTopics.add(new NewTopic(TEST_DLQ_TOPIC, TEST_DLQ_TOPIC_PARTITIONS, (short) 1));
+        adminClient.createTopics(testTopics).all().get();
+
+        connectRunner = new ConnectRunner(pluginsDir, kafka.getBootstrapServers());
+        connectRunner.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        connectRunner.stop();
+        adminClient.close();
+        producer.close();
+
+        connectRunner.awaitStop();
+
+        mockServer.stop();
+    }
+
+    @Test
+    @Timeout(60)
+    void testBasicDelivery() throws ExecutionException, InterruptedException {
+        // Make sure enabling Errant Record support doesn't affect basic delivery
+        final BodyRecorderHandler bodyRecorderHandler = new BodyRecorderHandler();
+        mockServer.addHandler(bodyRecorderHandler);
+        mockServer.start();
+
+        final Map<String, String> config = errantConnectorConfig();
+        connectRunner.createConnector(config);
+
+        final List<String> expectedBodies = new ArrayList<>();
+        final List<Future<RecordMetadata>> sendFutures = new ArrayList<>();
+        for (int i = 0; i < 1000; i++) {
+            for (int partition = 0; partition < TEST_TOPIC_PARTITIONS; partition++) {
+                final String key = "key-" + i;
+                final var recordName = "user-" + i;
+                final var recordValue = "value-" + i;
+                final Record value = new Record(recordName, recordValue);
+                expectedBodies.add(String.format(JSON_PATTERN, recordName, recordValue));
+                sendFutures.add(sendMessageAsync(partition, key, value));
+            }
+        }
+        producer.flush();
+        for (final Future<RecordMetadata> sendFuture : sendFutures) {
+            sendFuture.get();
+        }
+
+        await("All expected requests received by HTTP server")
+                .atMost(Duration.ofSeconds(15)).pollInterval(Duration.ofMillis(100))
+                .until(() -> bodyRecorderHandler.recorderBodies().size() >= expectedBodies.size());
+
+        assertThat(bodyRecorderHandler.recorderBodies()).containsExactlyElementsOf(expectedBodies);
+
+        log.info("{} HTTP requests were expected, {} were successfully delivered",
+            expectedBodies.size(),
+            bodyRecorderHandler.recorderBodies().size());
+    }
+
+    @Test
+    @Timeout(30)
+    void testFailingEvery3rdRequest() throws ExecutionException, InterruptedException {
+        final FailingPeriodicHandler failingPeriodicHandler = new FailingPeriodicHandler(FAIL_PERIOD);
+        mockServer.addHandler(failingPeriodicHandler);
+        mockServer.start();
+
+        final Map<String, String> config = errantConnectorConfig();
+        config.put("retry.backoff.ms", "0");
+        config.put("max.retries", "0");
+        connectRunner.createConnector(config);
+
+        log.info("Setting up consumer for test");
+
+        // set up consumer on DLQ
+        final Map<String, Object> consumerProps = Map.of(
+            ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers(),
+            ConsumerConfig.GROUP_ID_CONFIG, "kafka-connect-httpsink-test",
+            ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+            "org.apache.kafka.common.serialization.ByteArrayDeserializer",
+            ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+            "org.apache.kafka.common.serialization.ByteArrayDeserializer",
+            ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "1",
+            ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"
+        );
+
+        consumer = new KafkaConsumer<>(consumerProps);
+        consumer.subscribe(List.of(TEST_DLQ_TOPIC));
+
+        final List<String> expectedBodies = new ArrayList<>();
+        final List<String> errantBodies = new ArrayList<>();
+        final List<Future<RecordMetadata>> sendFutures = new ArrayList<>();
+        for (int i = 0; i < 15; i++) {
+            for (int partition = 0; partition < TEST_TOPIC_PARTITIONS; partition++) {
+                final String key = "key-" + i;
+                final var recordName = "user-" + i;
+                final var recordValue = "value-" + i;
+                final Record value = new Record(recordName, recordValue);
+                if (i % FAIL_PERIOD == 0) {
+                    errantBodies.add(String.format(JSON_PATTERN, recordName, recordValue));
+                } else {
+                    expectedBodies.add(String.format(JSON_PATTERN, recordName, recordValue));
+                }
+                sendFutures.add(sendMessageAsync(partition, key, value));
+            }
+        }
+        producer.flush();
+        for (final Future<RecordMetadata> sendFuture : sendFutures) {
+            sendFuture.get();
+        }
+
+        await("All expected requests received by HTTP server")
+                .atMost(Duration.ofSeconds(10)).pollInterval(Duration.ofMillis(100))
+                .until(() -> failingPeriodicHandler.recorderBodies().size() >= expectedBodies.size());
+
+        assertThat(failingPeriodicHandler.recorderBodies()).containsExactlyElementsOf(expectedBodies);
+
+        log.info("{} HTTP requests were expected, {} were successfully delivered",
+            expectedBodies.size(),
+            failingPeriodicHandler.recorderBodies().size());
+
+        // read from the DLQ
+        final int readConsumerRetries = 100;   
+        int noRecordsCount = 0;
+        final List<String> dlqBodies = new ArrayList<>();
+
+        while (noRecordsCount < readConsumerRetries) {
+            final ConsumerRecords<String, Record> consumerRecords = 
+                    consumer.poll(Duration.ofMillis(100));
+
+            if (consumerRecords.count() == 0) {
+                noRecordsCount++;
+                continue;
+            }
+
+            for (final ConsumerRecord<String, Record> record : consumerRecords) {
+                dlqBodies.add(String.format(JSON_PATTERN, record.key(), record.value()));
+            }
+            consumer.commitAsync();
+        }
+        consumer.close();
+
+        // checking that all failed messages were on the DLQ
+        assertThat(errantBodies.containsAll(dlqBodies));
+
+        log.info("There were {} failed HTTP requests were expected, {} were found on the DLQ",
+            errantBodies.size(), dlqBodies.size());
+    }
+
+    private Map<String, String> errantConnectorConfig() {
+        // get around the limit of 10 entries in Map.of()
+        final Map<String, String> map = Map.ofEntries(
+            new AbstractMap.SimpleEntry<>("name", CONNECTOR_NAME),
+            new AbstractMap.SimpleEntry<>("connector.class", HttpSinkConnector.class.getName()),
+            new AbstractMap.SimpleEntry<>("topics", TEST_TOPIC),
+            new AbstractMap.SimpleEntry<>("key.converter", "org.apache.kafka.connect.json.JsonConverter"),
+            new AbstractMap.SimpleEntry<>("value.converter", "org.apache.kafka.connect.json.JsonConverter"),
+            new AbstractMap.SimpleEntry<>("tasks.max", "1"),
+            new AbstractMap.SimpleEntry<>("key.converter.schemas.enable", "false"),
+            new AbstractMap.SimpleEntry<>("value.converter.schemas.enable", "false"),
+            new AbstractMap.SimpleEntry<>("http.url", "http://localhost:" + mockServer.localPort() + HTTP_PATH),
+            new AbstractMap.SimpleEntry<>("http.authorization.type", "static"),
+            new AbstractMap.SimpleEntry<>("http.headers.authorization", AUTHORIZATION),
+            new AbstractMap.SimpleEntry<>("http.headers.content.type", CONTENT_TYPE),
+            new AbstractMap.SimpleEntry<>("errors.tolerance", "all"),
+            new AbstractMap.SimpleEntry<>("errors.deadletterqueue.topic.name", TEST_DLQ_TOPIC),
+            new AbstractMap.SimpleEntry<>("errors.deadletterqueue.context.headers.enable", "true"),
+            new AbstractMap.SimpleEntry<>("errors.deadletterqueue.context.topic.replication.factor", 
+                                          TEST_DLQ_TOPIC_REPLICATION_FACTOR)
+            );
+
+        return new HashMap<>(map);    
+    }
+
+    private static class Record {
+        @JsonProperty
+        private final String record;
+
+        @JsonProperty
+        private final String recordValue;
+
+        public Record(final String record, final String recordValue) {
+            this.record = record;
+            this.recordValue = recordValue;
+        }
+
+        public String getRecordValue() {
+            return this.recordValue;
+        }
+    }
+
+    private Future<RecordMetadata> sendMessageAsync(final int partition,
+                                                    final String key,
+                                                    final Record value) {
+        final ProducerRecord<String, Record> msg = new ProducerRecord<>(
+                TEST_TOPIC, partition, key, value);
+        return producer.send(msg);
+    }
+}

--- a/src/integration-test/java/io/aiven/kafka/connect/http/ErrantRecordTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/ErrantRecordTest.java
@@ -85,7 +85,7 @@ final class ErrantRecordTest {
 
     private static File pluginsDir;
 
-    private static final String DEFAULT_TAG = "6.2.2";
+    private static final String DEFAULT_TAG = "6.0.2";
 
     private static final DockerImageName DEFAULT_IMAGE_NAME =
             DockerImageName.parse("confluentinc/cp-kafka").withTag(DEFAULT_TAG);

--- a/src/integration-test/java/io/aiven/kafka/connect/http/IntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/IntegrationTest.java
@@ -72,13 +72,13 @@ final class IntegrationTest {
 
     private static File pluginsDir;
 
-    private static final String DEFAULT_TAG = "5.4.3";
+    private static final String DEFAULT_TAG = "6.2.2";
 
     private static final DockerImageName DEFAULT_IMAGE_NAME =
             DockerImageName.parse("confluentinc/cp-kafka").withTag(DEFAULT_TAG);
 
     @Container
-    private final KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.2"))
+    private final KafkaContainer kafka = new KafkaContainer(DEFAULT_IMAGE_NAME)
         .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false");
 
     private AdminClient adminClient;

--- a/src/integration-test/java/io/aiven/kafka/connect/http/IntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/IntegrationTest.java
@@ -78,7 +78,7 @@ final class IntegrationTest {
             DockerImageName.parse("confluentinc/cp-kafka").withTag(DEFAULT_TAG);
 
     @Container
-    private final KafkaContainer kafka = new KafkaContainer(DEFAULT_IMAGE_NAME)
+    private final KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.2"))
         .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false");
 
     private AdminClient adminClient;

--- a/src/integration-test/java/io/aiven/kafka/connect/http/IntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/IntegrationTest.java
@@ -72,7 +72,7 @@ final class IntegrationTest {
 
     private static File pluginsDir;
 
-    private static final String DEFAULT_TAG = "6.2.2";
+    private static final String DEFAULT_TAG = "6.0.2";
 
     private static final DockerImageName DEFAULT_IMAGE_NAME =
             DockerImageName.parse("confluentinc/cp-kafka").withTag(DEFAULT_TAG);

--- a/src/integration-test/java/io/aiven/kafka/connect/http/JsonIntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/JsonIntegrationTest.java
@@ -69,13 +69,13 @@ public class JsonIntegrationTest {
 
     private static File pluginsDir;
 
-    private static final String DEFAULT_TAG = "5.4.3";
+    private static final String DEFAULT_TAG = "6.2.2";
 
     private static final DockerImageName DEFAULT_IMAGE_NAME =
             DockerImageName.parse("confluentinc/cp-kafka").withTag(DEFAULT_TAG);
 
     @Container
-    private final KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.2"))
+    private final KafkaContainer kafka = new KafkaContainer(DEFAULT_IMAGE_NAME)
             .withNetwork(Network.newNetwork())
             .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false");
 

--- a/src/integration-test/java/io/aiven/kafka/connect/http/JsonIntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/JsonIntegrationTest.java
@@ -53,7 +53,6 @@ import org.testcontainers.utility.DockerImageName;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 
 @Testcontainers
 public class JsonIntegrationTest {

--- a/src/integration-test/java/io/aiven/kafka/connect/http/JsonIntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/JsonIntegrationTest.java
@@ -69,7 +69,7 @@ public class JsonIntegrationTest {
 
     private static File pluginsDir;
 
-    private static final String DEFAULT_TAG = "6.2.2";
+    private static final String DEFAULT_TAG = "6.0.2";
 
     private static final DockerImageName DEFAULT_IMAGE_NAME =
             DockerImageName.parse("confluentinc/cp-kafka").withTag(DEFAULT_TAG);

--- a/src/integration-test/java/io/aiven/kafka/connect/http/JsonIntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/JsonIntegrationTest.java
@@ -53,6 +53,7 @@ import org.testcontainers.utility.DockerImageName;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 
 @Testcontainers
 public class JsonIntegrationTest {
@@ -75,7 +76,7 @@ public class JsonIntegrationTest {
             DockerImageName.parse("confluentinc/cp-kafka").withTag(DEFAULT_TAG);
 
     @Container
-    private final KafkaContainer kafka = new KafkaContainer(DEFAULT_IMAGE_NAME)
+    private final KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.2"))
             .withNetwork(Network.newNetwork())
             .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false");
 

--- a/src/integration-test/java/io/aiven/kafka/connect/http/SchemaRegistryContainer.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/SchemaRegistryContainer.java
@@ -24,7 +24,7 @@ final class SchemaRegistryContainer extends GenericContainer<SchemaRegistryConta
     public static final int SCHEMA_REGISTRY_PORT = 8081;
 
     public SchemaRegistryContainer(final KafkaContainer kafka) {
-        this("5.0.4", kafka);
+        this("6.2.2", kafka);
     }
 
     public SchemaRegistryContainer(final String confluentPlatformVersion, final KafkaContainer kafka) {

--- a/src/integration-test/java/io/aiven/kafka/connect/http/SchemaRegistryContainer.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/SchemaRegistryContainer.java
@@ -24,7 +24,7 @@ final class SchemaRegistryContainer extends GenericContainer<SchemaRegistryConta
     public static final int SCHEMA_REGISTRY_PORT = 8081;
 
     public SchemaRegistryContainer(final KafkaContainer kafka) {
-        this("6.2.2", kafka);
+        this("5.0.4", kafka);
     }
 
     public SchemaRegistryContainer(final String confluentPlatformVersion, final KafkaContainer kafka) {

--- a/src/integration-test/java/io/aiven/kafka/connect/http/mockserver/FailingPeriodicHandler.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/mockserver/FailingPeriodicHandler.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.http.mockserver;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+
+public final class FailingPeriodicHandler extends AbstractHandler {
+
+    private final List<String> recorderBodies = new CopyOnWriteArrayList<>();
+
+    private final int requestFailPeriod;
+
+    private int requestCounter = 0;
+
+    public FailingPeriodicHandler(final int requestFailPeriod) {
+        this.requestFailPeriod = requestFailPeriod;
+    }
+
+    @Override
+    public void handle(final String target,
+                       final Request baseRequest,
+                       final HttpServletRequest request,
+                       final HttpServletResponse response) throws IOException, ServletException {
+        if (requestCounter % requestFailPeriod == 0) {
+            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        } else {
+            recorderBodies.add(
+                new String(request.getInputStream().readAllBytes(), StandardCharsets.UTF_8)
+            );
+            response.setStatus(HttpServletResponse.SC_OK);
+        }
+
+        baseRequest.setHandled(true);
+
+        requestCounter += 1;
+    }
+
+    public List<String> recorderBodies() {
+        return List.copyOf(recorderBodies);
+    }
+}

--- a/src/integration-test/java/io/aiven/kafka/connect/http/mockserver/FailingPeriodicHandler.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/http/mockserver/FailingPeriodicHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Aiven Oy and http-connector-for-apache-kafka project contributors
+ * Copyright 2022 Aiven Oy and http-connector-for-apache-kafka project contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package io.aiven.kafka.connect.http.mockserver;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -44,7 +43,7 @@ public final class FailingPeriodicHandler extends AbstractHandler {
     public void handle(final String target,
                        final Request baseRequest,
                        final HttpServletRequest request,
-                       final HttpServletResponse response) throws IOException, ServletException {
+                       final HttpServletResponse response) throws IOException {
         if (requestCounter % requestFailPeriod == 0) {
             response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
         } else {

--- a/src/main/java/io/aiven/kafka/connect/http/HttpSinkTask.java
+++ b/src/main/java/io/aiven/kafka/connect/http/HttpSinkTask.java
@@ -77,7 +77,7 @@ public final class HttpSinkTask extends SinkTask {
             reporter = context.errantRecordReporter();
         } catch (NoClassDefFoundError | NoSuchMethodError e) {
             // Will occur in Connect runtimes earlier than 2.6
-            log.warn("AK versions prior to 2.6 do not support the errant record reporter.");
+            log.warn("Apache Kafka versions prior to 2.6 do not support the errant record reporter.");
         }
     }
 

--- a/src/main/java/io/aiven/kafka/connect/http/HttpSinkTask.java
+++ b/src/main/java/io/aiven/kafka/connect/http/HttpSinkTask.java
@@ -20,7 +20,9 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
 
@@ -36,6 +38,10 @@ public final class HttpSinkTask extends SinkTask {
 
     private HttpSender httpSender;
     private RecordSender recordSender;
+    private ErrantRecordReporter reporter;
+
+    // flag for legacy support (configured for batch mode, not using errors.tolerance)
+    private boolean useLegacySend;
 
     // required by Connect
     public HttpSinkTask() {
@@ -53,9 +59,25 @@ public final class HttpSinkTask extends SinkTask {
         if (this.httpSender == null) {
             this.httpSender = HttpSender.createHttpSender(config);
         }
+
         recordSender = RecordSender.createRecordSender(httpSender, config);
+
+        this.useLegacySend = config.batchingEnabled();
+
         if (Objects.nonNull(config.kafkaRetryBackoffMs())) {
             context.timeout(config.kafkaRetryBackoffMs());
+        }
+
+        try {
+            if (context.errantRecordReporter() == null) {
+                log.info("Errant record reporter not configured.");
+            }
+
+            // may be null if DLQ not enabled
+            reporter = context.errantRecordReporter();
+        } catch (NoClassDefFoundError | NoSuchMethodError e) {
+            // Will occur in Connect runtimes earlier than 2.6
+            log.warn("AK versions prior to 2.6 do not support the errant record reporter.");
         }
     }
 
@@ -64,12 +86,34 @@ public final class HttpSinkTask extends SinkTask {
         log.debug("Received {} records", records.size());
 
         if (!records.isEmpty()) {
-            for (final SinkRecord record : records) {
-                if (record.value() == null) {
-                    throw new DataException("Record value must not be null");
+            // use the legacy send if batch is enabled
+            if (this.useLegacySend) {
+                for (final SinkRecord record : records) {
+                    if (record.value() == null) {
+                        throw new DataException("Record value must not be null");
+                    }
+                }
+
+                recordSender.send(records);
+            } else {
+                // send records to the sender one at a time
+                for (final SinkRecord record : records) {
+                    if (record.value() == null) {
+                        throw new DataException("Record value must not be null");
+                    }
+
+                    try {
+                        recordSender.send(record);
+                    } catch (final ConnectException e) {
+                        if (reporter != null) {
+                            reporter.report(record, e);
+                        } else {
+                            // otherwise, re-throw the exception
+                            throw new ConnectException(e.getMessage());
+                        }
+                    }
                 }
             }
-            recordSender.send(records);
         }
     }
 

--- a/src/main/java/io/aiven/kafka/connect/http/recordsender/BatchRecordSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/recordsender/BatchRecordSender.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 import io.aiven.kafka.connect.http.sender.HttpSender;
@@ -59,6 +60,11 @@ final class BatchRecordSender extends RecordSender {
             final String body = createRequestBody(batch);
             httpSender.send(body);
         }
+    }
+
+    @Override
+    public void send(final SinkRecord record) {
+        throw new ConnectException("Don't call this method for batch sending");
     }
 
     private String createRequestBody(final Collection<SinkRecord> batch) {

--- a/src/main/java/io/aiven/kafka/connect/http/recordsender/RecordSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/recordsender/RecordSender.java
@@ -36,6 +36,8 @@ public abstract class RecordSender {
 
     public abstract void send(final Collection<SinkRecord> records);
 
+    public abstract void send(final SinkRecord record);
+
     public static RecordSender createRecordSender(final HttpSender httpSender, final HttpSinkConfig config) {
         if (config.batchingEnabled()) {
             return new BatchRecordSender(

--- a/src/main/java/io/aiven/kafka/connect/http/recordsender/SingleRecordSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/recordsender/SingleRecordSender.java
@@ -36,4 +36,9 @@ final class SingleRecordSender extends RecordSender {
         }
     }
 
+    @Override
+    public void send(final SinkRecord record) {
+        final String body = recordValueConverter.convert(record);
+        httpSender.send(body);
+    }
 }

--- a/src/test/java/io/aiven/kafka/connect/http/config/HttpSinkConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/config/HttpSinkConfigTest.java
@@ -530,4 +530,55 @@ final class HttpSinkConfigTest {
         final var config = new HttpSinkConfig(properties);
         assertThat(config.httpTimeout()).isEqualTo(5);
     }
+
+    @Test
+    void invalidConfig() {
+        final Map<String, String> properties = Map.of(
+                "http.url", "http://localhost:8090",
+                "http.authorization.type", "none",
+                "batching.enabled", "true",
+                "errors.tolerance", "all"
+        );
+
+        final var batchingAndErrorsToleranceE =
+                assertThrows(ConfigException.class, () -> new HttpSinkConfig(properties));
+
+        assertEquals(
+                "Cannot use errors.tolerance when batching is enabled",
+                        batchingAndErrorsToleranceE.getMessage());
+    }
+
+    @Test
+    void validBatchingConfig() {
+        Map<String, String> properties;
+
+        properties = Map.of(
+                "http.url", "http://localhost:8090",
+                "http.authorization.type", "none",
+                "batching.enabled", "false",
+                "errors.tolerance", "all"
+        );
+
+        var config = new HttpSinkConfig(properties);
+        assertFalse(config.batchingEnabled());
+
+        properties = Map.of(
+                "http.url", "http://localhost:8090",
+                "http.authorization.type", "none",
+                "batching.enabled", "true"
+        );
+
+        config = new HttpSinkConfig(properties);
+        assertTrue(config.batchingEnabled());
+
+        properties = Map.of(
+                "http.url", "http://localhost:8090",
+                "http.authorization.type", "none",
+                "batching.enabled", "true",
+                "errors.tolerance", "none"
+        );
+
+        config = new HttpSinkConfig(properties);
+        assertTrue(config.batchingEnabled());
+    }
 }

--- a/src/test/java/io/aiven/kafka/connect/http/config/HttpSinkConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/config/HttpSinkConfigTest.java
@@ -38,6 +38,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.from;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 final class HttpSinkConfigTest {
 

--- a/src/test/java/io/aiven/kafka/connect/http/config/HttpSinkConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/config/HttpSinkConfigTest.java
@@ -38,10 +38,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assertions.from;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 final class HttpSinkConfigTest {
 
@@ -544,12 +540,10 @@ final class HttpSinkConfigTest {
                 "errors.tolerance", "all"
         );
 
-        final var batchingAndErrorsToleranceE =
-                assertThrows(ConfigException.class, () -> new HttpSinkConfig(properties));
-
-        assertEquals(
-                "Cannot use errors.tolerance when batching is enabled",
-                        batchingAndErrorsToleranceE.getMessage());
+        assertThatExceptionOfType(ConfigException.class)
+                .describedAs("Cannot use errors.tolerance when batching is enabled")
+                .isThrownBy(() -> new HttpSinkConfig(properties))
+                .withMessage("Cannot use errors.tolerance when batching is enabled");
     }
 
     @Test
@@ -564,7 +558,7 @@ final class HttpSinkConfigTest {
         );
 
         var config = new HttpSinkConfig(properties);
-        assertFalse(config.batchingEnabled());
+        assertThat(config.batchingEnabled()).isFalse();
 
         properties = Map.of(
                 "http.url", "http://localhost:8090",
@@ -573,7 +567,7 @@ final class HttpSinkConfigTest {
         );
 
         config = new HttpSinkConfig(properties);
-        assertTrue(config.batchingEnabled());
+        assertThat(config.batchingEnabled()).isTrue();
 
         properties = Map.of(
                 "http.url", "http://localhost:8090",
@@ -583,6 +577,6 @@ final class HttpSinkConfigTest {
         );
 
         config = new HttpSinkConfig(properties);
-        assertTrue(config.batchingEnabled());
+        assertThat(config.batchingEnabled()).isTrue();
     }
 }


### PR DESCRIPTION
Add errors.tolerance and ErrantRecordReporter support.
Updating to support kafkaVersion 2.6 which is when
ErrantRecordReporter became available in Kafka connect. Can
also add the following parameters to the http-sink properties
file to handle messages that are reported to the
ErrantRecordReporter.
errors.deadletterqueue.topic.name
errors.deadletterqueue.context.headers.enable
errors.deadletterqueue.topic.replication.factor

Preserving backwards compatibility on batch send by only using
ErrantRecordReporting if non-batch.