### PR TITLE
OAuth token update fix

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/http/sender/OAuth2HttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/OAuth2HttpSender.java
@@ -79,7 +79,7 @@ final class OAuth2HttpSender extends HttpSender {
                 throw new ConnectException("Couldn't get OAuth2 access token", e);
             }
         }
-        return requestBuilder.header(HttpRequestBuilder.HEADER_AUTHORIZATION, accessTokenAuthHeader);
+        return requestBuilder.setHeader(HttpRequestBuilder.HEADER_AUTHORIZATION, accessTokenAuthHeader);
     }
 
     private String buildAccessTokenAuthHeader(final String responseBody) throws JsonProcessingException {

--- a/src/test/java/io/aiven/kafka/connect/http/sender/OAuth2HttpSenderTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/sender/OAuth2HttpSenderTest.java
@@ -240,6 +240,13 @@ class OAuth2HttpSenderTest {
                 .filteredOnAssertions(uri ->
                         assertThat(uri).hasToString("http://localhost:42/token"))
                 .hasSize(2);
+
+        assertThat(requestCaptor.getAllValues())
+                .filteredOnAssertions(req ->
+                        assertThat(req.uri()).hasToString("http://localhost:42"))
+                .allSatisfy(request ->
+                        assertThat(request.headers().allValues("Authorization")).hasSize(1));
+
     }
 
     @Test


### PR DESCRIPTION
Since we are reusing `HttpRequest.Builder` after OAuth token update both tokens(old and new) appear in the request header like this `Authorization: [Bearer old-token, Bearer new-token]` however only new token should be there.