### PR TITLE
feat: Handle ApiKey authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We consider the connector **stable** despite the major version is currently 0.
 The connector uses the POST HTTP method to deliver records.
 
 The connector supports:
-- authorization (static, OAuth2);
+- authorization (static, OAuth2, Apikey);
 - setting HTTP headers;
 - batching;
 - delivery retries.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 version=0.7.0-SNAPSHOT
+https.protocols=TLSv1.2,TLSv1.3

--- a/src/main/java/io/aiven/kafka/connect/http/config/AuthorizationType.java
+++ b/src/main/java/io/aiven/kafka/connect/http/config/AuthorizationType.java
@@ -24,7 +24,8 @@ import java.util.stream.Collectors;
 public enum AuthorizationType {
     NONE("none"),
     OAUTH2("oauth2"),
-    STATIC("static");
+    STATIC("static"),
+    APIKEY("apikey");
 
     public final String name;
 
@@ -41,6 +42,8 @@ public enum AuthorizationType {
             return OAUTH2;
         } else if (STATIC.name.equalsIgnoreCase(name)) {
             return STATIC;
+        } else if (APIKEY.name.equalsIgnoreCase(name)) {
+            return APIKEY;
         } else {
             throw new IllegalArgumentException("Unknown authorization type: " + name);
         }

--- a/src/main/java/io/aiven/kafka/connect/http/sender/AccessTokenHttpRequestBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/AccessTokenHttpRequestBuilder.java
@@ -21,26 +21,27 @@ import java.net.http.HttpRequest;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Base64;
-import java.util.Objects;
 import java.util.StringJoiner;
 
 import org.apache.kafka.connect.errors.ConnectException;
 
+import io.aiven.kafka.connect.http.config.AuthorizationType;
 import io.aiven.kafka.connect.http.config.HttpSinkConfig;
+import io.aiven.kafka.connect.http.sender.HttpRequestBuilder.OAuth2HttpRequestBuilder;
 
-class AccessTokenHttpRequestBuilder implements HttpRequestBuilder {
+class AccessTokenHttpRequestBuilder implements OAuth2HttpRequestBuilder {
 
     AccessTokenHttpRequestBuilder() {
     }
 
     @Override
     public HttpRequest.Builder build(final HttpSinkConfig config) {
-        Objects.requireNonNull(config, "config");
-        Objects.requireNonNull(config.oauth2AccessTokenUri(), "oauth2AccessTokenUri");
+        VALIDATE.accept(config, AuthorizationType.OAUTH2);
+
         final var accessTokenRequestBuilder = HttpRequest
-                        .newBuilder(config.oauth2AccessTokenUri())
-                        .timeout(Duration.ofSeconds(config.httpTimeout()))
-                        .header(HEADER_CONTENT_TYPE, "application/x-www-form-urlencoded");
+                .newBuilder(config.oauth2AccessTokenUri())
+                .timeout(Duration.ofSeconds(config.httpTimeout()))
+                .header(HEADER_CONTENT_TYPE, HEADER_CONTENT_TYPE_FORM);
 
         final var accessTokenRequestBodyBuilder = new StringJoiner("&");
         accessTokenRequestBodyBuilder.add(encodeNameAndValue("grant_type", "client_credentials"));

--- a/src/main/java/io/aiven/kafka/connect/http/sender/ApiKeyAccessTokenHttpRequestBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/ApiKeyAccessTokenHttpRequestBuilder.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021 Aiven Oy and http-connector-for-apache-kafka project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.http.sender;
+
+import java.net.http.HttpRequest;
+import java.time.Duration;
+
+import org.apache.kafka.connect.errors.ConnectException;
+
+import io.aiven.kafka.connect.http.config.AuthorizationType;
+import io.aiven.kafka.connect.http.config.HttpSinkConfig;
+import io.aiven.kafka.connect.http.sender.HttpRequestBuilder.OAuth2HttpRequestBuilder;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ApiKeyAccessTokenHttpRequestBuilder implements OAuth2HttpRequestBuilder {
+    ApiKeyAccessTokenHttpRequestBuilder() {
+    }
+
+    @Override
+    public HttpRequest.Builder build(final HttpSinkConfig config) {
+        VALIDATE.accept(config, AuthorizationType.APIKEY);
+
+        final var accessTokenRequestBuilder = HttpRequest
+                .newBuilder(config.oauth2AccessTokenUri())
+                .timeout(Duration.ofSeconds(config.httpTimeout()))
+                .header(HEADER_CONTENT_TYPE, HEADER_CONTENT_TYPE_FORM);
+
+        final AccessTokenRequest accessTokenRequest = new AccessTokenRequest("api-key", config.oauth2ClientId(),
+                config.oauth2ClientSecret().value());
+
+        final ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            final String requestBody = objectMapper
+                    .writerWithDefaultPrettyPrinter()
+                    .writeValueAsString(accessTokenRequest);
+            return accessTokenRequestBuilder
+                    .POST(HttpRequest.BodyPublishers.ofString(requestBody));
+        } catch (final JsonProcessingException e) {
+            throw new ConnectException("Cannot get OAuth2 access token from ApiKey Authentication", e);
+        }
+    }
+
+    private static class AccessTokenRequest {
+        final String type;
+        final String key;
+        final String secret;
+
+        public AccessTokenRequest(final String type, final String key, final String secret) {
+            this.type = type;
+            this.key = key;
+            this.secret = secret;
+        }
+
+        //Getters needed for serdes
+        public String getType() {
+            return type;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public String getSecret() {
+            return secret;
+        }
+    }
+
+}

--- a/src/main/java/io/aiven/kafka/connect/http/sender/HttpRequestBuilder.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/HttpRequestBuilder.java
@@ -18,7 +18,10 @@ package io.aiven.kafka.connect.http.sender;
 
 import java.net.http.HttpRequest;
 import java.time.Duration;
+import java.util.Objects;
+import java.util.function.BiConsumer;
 
+import io.aiven.kafka.connect.http.config.AuthorizationType;
 import io.aiven.kafka.connect.http.config.HttpSinkConfig;
 
 interface HttpRequestBuilder {
@@ -42,4 +45,14 @@ interface HttpRequestBuilder {
     HttpRequestBuilder AUTH_HTTP_REQUEST_BUILDER = config -> DEFAULT_HTTP_REQUEST_BUILDER.build(config)
             .header(HEADER_AUTHORIZATION, config.headerAuthorization());
 
+    interface OAuth2HttpRequestBuilder extends HttpRequestBuilder {
+        String HEADER_CONTENT_TYPE_FORM = "application/x-www-form-urlencoded";
+        BiConsumer<HttpSinkConfig, AuthorizationType> VALIDATE = (httpSinkConfig, authorizationType) -> {
+            Objects.requireNonNull(httpSinkConfig, "config should not be null");
+            if (httpSinkConfig.authorizationType() != authorizationType) {
+                throw new IllegalArgumentException(String.format("The expected authorization type is %s",
+                        authorizationType.name));
+            }
+        };
+    }
 }

--- a/src/main/java/io/aiven/kafka/connect/http/sender/HttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/HttpSender.java
@@ -29,6 +29,7 @@ import io.aiven.kafka.connect.http.config.HttpSinkConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 public class HttpSender {
 
     private static final Logger log = LoggerFactory.getLogger(HttpSender.class);
@@ -40,7 +41,7 @@ public class HttpSender {
     private final HttpRequestBuilder httpRequestBuilder;
 
     protected HttpSender(final HttpSinkConfig config) {
-        this(config, HttpRequestBuilder.DEFAULT_HTTP_REQUEST_BUILDER, HttpClient.newHttpClient());
+        this(config, HttpRequestBuilder.DEFAULT_HTTP_REQUEST_BUILDER);
     }
 
     protected HttpSender(final HttpSinkConfig config,
@@ -107,7 +108,9 @@ public class HttpSender {
             case STATIC:
                 return new HttpSender(config, HttpRequestBuilder.AUTH_HTTP_REQUEST_BUILDER);
             case OAUTH2:
-                return new OAuth2HttpSender(config);
+                return new OAuth2HttpSender(config, new AccessTokenHttpRequestBuilder());
+            case APIKEY:
+                return new OAuth2HttpSender(config, new ApiKeyAccessTokenHttpRequestBuilder());
             default:
                 throw new ConnectException("Can't create HTTP sender for auth type: " + config.authorizationType());
         }

--- a/src/main/java/io/aiven/kafka/connect/http/sender/OAuth2HttpSender.java
+++ b/src/main/java/io/aiven/kafka/connect/http/sender/OAuth2HttpSender.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.apache.kafka.connect.errors.ConnectException;
 
 import io.aiven.kafka.connect.http.config.HttpSinkConfig;
+import io.aiven.kafka.connect.http.sender.HttpRequestBuilder.OAuth2HttpRequestBuilder;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -40,13 +41,17 @@ final class OAuth2HttpSender extends HttpSender {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    OAuth2HttpSender(final HttpSinkConfig config) {
+    private final OAuth2HttpRequestBuilder oauth2HttpRequestBuilder;
+
+    OAuth2HttpSender(final HttpSinkConfig config, final OAuth2HttpRequestBuilder accessTokenRequestBuilder) {
         super(config);
+        this.oauth2HttpRequestBuilder = accessTokenRequestBuilder;
     }
 
     //for testing
     OAuth2HttpSender(final HttpSinkConfig config, final HttpClient httpClient) {
         super(config, httpClient);
+        this.oauth2HttpRequestBuilder = new AccessTokenHttpRequestBuilder();
     }
 
     @Override
@@ -71,7 +76,7 @@ final class OAuth2HttpSender extends HttpSender {
             try {
                 final var response =
                         super.sendWithRetries(
-                                new AccessTokenHttpRequestBuilder().build(config),
+                                oauth2HttpRequestBuilder.build(config),
                                 HttpResponseHandler.ON_HTTP_ERROR_RESPONSE_HANDLER
                         );
                 accessTokenAuthHeader = buildAccessTokenAuthHeader(response.body());

--- a/src/test/java/io/aiven/kafka/connect/http/config/HttpSinkConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/config/HttpSinkConfigTest.java
@@ -68,7 +68,6 @@ final class HttpSinkConfigTest {
                 .returns(1, from(HttpSinkConfig::maxRetries))
                 .returns(3000, from(HttpSinkConfig::retryBackoffMs))
                 .returns(Collections.emptyMap(), from(HttpSinkConfig::getAdditionalHeaders))
-                .returns(null, from(HttpSinkConfig::oauth2AccessTokenUri))
                 .returns(null, from(HttpSinkConfig::oauth2ClientId))
                 .returns(null, from(HttpSinkConfig::oauth2ClientSecret))
                 .returns(null, from(HttpSinkConfig::oauth2ClientScope))
@@ -120,22 +119,24 @@ final class HttpSinkConfigTest {
                         + "supported values are: [HEADER, URL]");
     }
 
-    @Test
-    void invalidOAuth2Configuration() {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"OAUTH2", "APIKEY"})
+    void invalidOAuth2Configuration(final String input) {
         final var noAccessTokenUrlConfig = Map.of(
                 "http.url", "http://localhost:8090",
-                "http.authorization.type", "oauth2"
+                "http.authorization.type", input.toLowerCase()
         );
 
         assertThatExceptionOfType(ConfigException.class)
                 .describedAs("Expected config exception due to missing OAuth access token URL")
                 .isThrownBy(() -> new HttpSinkConfig(noAccessTokenUrlConfig))
                 .withMessage("Invalid value null for configuration oauth2.access.token.url: "
-                        + "Must be present when http.headers.content.type = OAUTH2");
+                        + "Must be present when http.headers.content.type = " + input);
 
         final var noSecretIdConfig = Map.of(
                 "http.url", "http://localhost:8090",
-                "http.authorization.type", "oauth2",
+                "http.authorization.type", input.toLowerCase(),
                 "oauth2.access.token.url", "http://localhost:8090/token"
         );
 
@@ -143,11 +144,11 @@ final class HttpSinkConfigTest {
                 .describedAs("Expected config exception due to missing OAuth client id")
                 .isThrownBy(() -> new HttpSinkConfig(noSecretIdConfig))
                 .withMessage("Invalid value null for configuration oauth2.client.id: "
-                        + "Must be present when http.headers.content.type = OAUTH2");
+                        + "Must be present when http.headers.content.type = " + input);
 
         final var noSecretConfig = Map.of(
                 "http.url", "http://localhost:8090",
-                "http.authorization.type", "oauth2",
+                "http.authorization.type", input.toLowerCase(),
                 "oauth2.access.token.url", "http://localhost:8090/token",
                 "oauth2.client.id", "client_id"
         );
@@ -156,7 +157,7 @@ final class HttpSinkConfigTest {
                 .describedAs("Expected config exception due to missing OAuth client secret")
                 .isThrownBy(() -> new HttpSinkConfig(noSecretConfig))
                 .withMessage("Invalid value null for configuration oauth2.client.secret: "
-                        + "Must be present when http.headers.content.type = OAUTH2");
+                        + "Must be present when http.headers.content.type = " + input);
     }
 
     @Test
@@ -263,6 +264,14 @@ final class HttpSinkConfigTest {
                                 "oauth2.access.token.url", "http://localhost:42",
                                 "oauth2.client.id", "client_id",
                                 "oauth2.client.secret", "client_secret"
+                        )),
+                Arguments.of(AuthorizationType.APIKEY,
+                        Map.of(
+                                "http.url", "http://localhost:8090",
+                                "http.authorization.type", AuthorizationType.APIKEY.name,
+                                "oauth2.access.token.url", "http://localhost:42",
+                                "oauth2.client.id", "key",
+                                "oauth2.client.secret", "secret"
                         ))
         );
     }
@@ -278,7 +287,7 @@ final class HttpSinkConfigTest {
                 .describedAs("Expected config exception due to unsupported authorization type")
                 .isThrownBy(() -> new HttpSinkConfig(properties))
                 .withMessage("Invalid value unsupported for configuration http.authorization.type: "
-                        + "supported values are: [none, oauth2, static]");
+                        + "supported values are: [none, oauth2, static, apikey]");
     }
 
     @Test

--- a/src/test/java/io/aiven/kafka/connect/http/sender/AccessTokenHttpRequestBuilderTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/sender/AccessTokenHttpRequestBuilderTest.java
@@ -28,8 +28,35 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class AccessTokenHttpRequestBuilderTest {
+
+    @Test
+    void shouldThrowExceptionWithoutConfig() {
+        final Exception thrown = assertThrows(NullPointerException.class, () ->
+                new AccessTokenHttpRequestBuilder().build(null).build()
+        );
+        assertEquals("config should not be null", thrown.getMessage());
+    }
+
+    @Test
+    void shouldThrowExceptionWithoutRightConfig() {
+        final var configBase = Map.of(
+                "http.url", "http://localhost:42",
+                "http.authorization.type", "apikey",
+                "oauth2.access.token.url", "http://localhost:42/token",
+                "oauth2.client.id", "some_client_id",
+                "oauth2.client.secret", "some_client_secret"
+        );
+        final HttpSinkConfig config = new HttpSinkConfig(configBase);
+
+        final Exception thrown = assertThrows(IllegalArgumentException.class, () ->
+                new AccessTokenHttpRequestBuilder().build(config).build()
+        );
+        assertEquals("The expected authorization type is oauth2", thrown.getMessage());
+    }
 
     @Test
     void shouldBuildDefaultAccessTokenRequest() throws Exception {

--- a/src/test/java/io/aiven/kafka/connect/http/sender/ApiKeyAccessTokenHttpRequestBuilderTest.java
+++ b/src/test/java/io/aiven/kafka/connect/http/sender/ApiKeyAccessTokenHttpRequestBuilderTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 Aiven Oy and http-connector-for-apache-kafka project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.http.sender;
+
+import java.net.URL;
+import java.util.Map;
+
+import io.aiven.kafka.connect.http.config.HttpSinkConfig;
+
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ApiKeyAccessTokenHttpRequestBuilderTest {
+
+    @Test
+    void shouldBuildDefaultAccessTokenRequest() throws Exception {
+        final var configBase = Map.of(
+                "http.url", "http://localhost:42",
+                "http.authorization.type", "apikey",
+                "oauth2.access.token.url", "http://localhost:42/token",
+                "oauth2.client.id", "some_client_id",
+                "oauth2.client.secret", "some_client_secret"
+        );
+        final HttpSinkConfig config = new HttpSinkConfig(configBase);
+        final var accessTokenRequest =
+                new ApiKeyAccessTokenHttpRequestBuilder().build(config).build();
+
+        assertThat(accessTokenRequest.uri()).isEqualTo(new URL("http://localhost:42/token").toURI());
+
+        assertThat(accessTokenRequest.timeout()).isPresent()
+                .get(as(InstanceOfAssertFactories.DURATION))
+                .hasSeconds(config.httpTimeout());
+        assertThat(accessTokenRequest.method()).isEqualTo("POST");
+        assertThat(accessTokenRequest.headers().firstValue(HttpRequestBuilder.HEADER_CONTENT_TYPE))
+                .hasValue("application/x-www-form-urlencoded");
+
+    }
+
+    @Test
+    void shouldThrowExceptionWithoutConfig() {
+        final Exception thrown = assertThrows(NullPointerException.class, () ->
+            new ApiKeyAccessTokenHttpRequestBuilder().build(null).build()
+        );
+        assertEquals("config should not be null", thrown.getMessage());
+    }
+
+    @Test
+    void shouldThrowExceptionWithoutRightConfig() {
+        final var configBase = Map.of(
+                "http.url", "http://localhost:42",
+                "http.authorization.type", "oauth2",
+                "oauth2.access.token.url", "http://localhost:42/token",
+                "oauth2.client.id", "some_client_id",
+                "oauth2.client.secret", "some_client_secret"
+        );
+        final HttpSinkConfig config = new HttpSinkConfig(configBase);
+
+        final Exception thrown = assertThrows(IllegalArgumentException.class, () ->
+            new ApiKeyAccessTokenHttpRequestBuilder().build(config).build()
+        );
+        assertEquals("The expected authorization type is apikey", thrown.getMessage());
+    }
+}


### PR DESCRIPTION
Goal: Be able to authenticate to an API Management with an apikey and secret to retrieve an access token.
Changes:
- add configuration **apikey**
- specific apikey request builder for OAuth2HttpSender to retrieve access token
- refactoring OAuth2HttpSender to accept custom builders (add specific interface for oauth2 request builders)
- add unit tests